### PR TITLE
Display dates and times only after selected by user

### DIFF
--- a/components/Trip/Trip.js
+++ b/components/Trip/Trip.js
@@ -439,7 +439,10 @@ export class Trip extends Component {
                 date={this.state.endDate}
                 onDateChange={(date) => this.setState({ endDate: date })}
                 />
-              <TouchableOpacity onPress={() => this.toggleModal("endDate_modal")}>
+              <TouchableOpacity onPress={() => {
+                this.setState({ selectedEndDate: true })
+                this.toggleModal("endDate_modal")
+                }}>
                 <Text style={styles.updateBtn}>Submit End Date</Text>
               </TouchableOpacity>
             </View>
@@ -457,7 +460,10 @@ export class Trip extends Component {
                 date={this.state.notificationDate}
                 onDateChange={(date) => this.setState({ notificationDate: date })}
                 />
-              <TouchableOpacity onPress={() => this.toggleModal("notificationDate_modal")}>
+              <TouchableOpacity onPress={() => {
+                this.setState({ selectedNotificationDate: true })
+                this.toggleModal("notificationDate_modal")
+              }}>
                 <Text style={styles.updateBtn}>Submit Notification Date</Text>
               </TouchableOpacity>
             </View>
@@ -475,7 +481,10 @@ export class Trip extends Component {
                 date={this.state.startTime}
                 onDateChange={(time) => this.setState({ startTime: time })}
               />
-              <TouchableOpacity onPress={() => this.toggleModal("startTime_modal")}>
+              <TouchableOpacity onPress={() => {
+                this.setState({ selectedStartTime: true })
+                this.toggleModal("startTime_modal")
+              }}>
                 <Text style={styles.updateBtn}>Submit Start Time</Text>
               </TouchableOpacity>
             </View>
@@ -495,7 +504,10 @@ export class Trip extends Component {
                   this.setState({ endTime: time })
                 }}
               />
-              <TouchableOpacity onPress={() => this.toggleModal("endTime_modal")}>
+              <TouchableOpacity onPress={() => {
+                this.setState({ selectedEndTime: true })
+                this.toggleModal("endTime_modal")
+              }}>
                 <Text style={styles.updateBtn}>Submit End Time</Text>
               </TouchableOpacity>
             </View>
@@ -515,7 +527,10 @@ export class Trip extends Component {
                   this.setState({ notificationTime: time })
                 }}
               />
-              <TouchableOpacity onPress={() => this.toggleModal("notificationTime_modal")}>
+              <TouchableOpacity onPress={() => {
+                this.setState({ selectedNotificationTime: true })
+                this.toggleModal("notificationTime_modal")
+              }}>
                 <Text style={styles.updateBtn}>Submit Notification Time</Text>
               </TouchableOpacity>
             </View>

--- a/components/Trip/Trip.js
+++ b/components/Trip/Trip.js
@@ -167,7 +167,13 @@ export class Trip extends Component {
       endTime: new Date(),
       notificationDate: new Date(),
       notificationTime: new Date(),
-      travelingCompanions: ""
+      travelingCompanions: "",
+      selectedStartDate: false,
+      selectedStartTime: false,
+      selectedEndDate: false,
+      selectedEndTime: false,
+      selectedNotificationDate: false,
+      selectedNotificationTime: false
     });
   }
 

--- a/components/Trip/Trip.js
+++ b/components/Trip/Trip.js
@@ -298,42 +298,54 @@ export class Trip extends Component {
           >
             <Text style={styles.modalToggleText}>Select Start Date</Text>
           </TouchableOpacity>
-          <Text style={styles.dateTime}>{this.formatDate(this.state.startDate)}</Text>
+          <View style={styles.dateTimeContainer}>
+            <Text style={styles.dateTime}>{this.formatDate(this.state.startDate)}</Text>
+          </View>
           <TouchableOpacity
             style={styles.modalToggleButton}
             onPress={() => this.toggleModal("startTime_modal")}
           >
             <Text style={styles.modalToggleText}>Select Start Time</Text>
           </TouchableOpacity>
-          <Text style={styles.dateTime}>{this.formatTime(this.state.startTime)}</Text>
+          <View style={styles.dateTimeContainer}>
+            <Text style={styles.dateTime}>{this.formatTime(this.state.startTime)}</Text>
+          </View>
           <TouchableOpacity
             style={styles.modalToggleButton}
             onPress={() => this.toggleModal("endDate_modal")}
           >
             <Text style={styles.modalToggleText}>Select End Date</Text>
           </TouchableOpacity>
-          <Text style={styles.dateTime}>{this.formatDate(this.state.endDate)}</Text>
+          <View style={styles.dateTimeContainer}>
+            <Text style={styles.dateTime}>{this.formatDate(this.state.endDate)}</Text>
+          </View>
           <TouchableOpacity
             style={styles.modalToggleButton}
             onPress={() => this.toggleModal("endTime_modal")}
           >
             <Text style={styles.modalToggleText}>Select End Time</Text>
           </TouchableOpacity>
-          <Text style={styles.dateTime}>{this.formatTime(this.state.endTime)}</Text>
+          <View style={styles.dateTimeContainer}>
+            <Text style={styles.dateTime}>{this.formatTime(this.state.endTime)}</Text>
+          </View>
           <TouchableOpacity
             style={styles.modalToggleButton}
             onPress={() => this.toggleModal("notificationDate_modal")}
           >
             <Text style={styles.modalToggleText}>Select Notification Date</Text>
           </TouchableOpacity>
-          <Text style={styles.dateTime}>{this.formatDate(this.state.notificationDate)}</Text>
+          <View style={styles.dateTimeContainer}>
+            <Text style={styles.dateTime}>{this.formatDate(this.state.notificationDate)}</Text>
+          </View>
           <TouchableOpacity
             style={styles.modalToggleButton}
             onPress={() => this.toggleModal("notificationTime_modal")}
           >
             <Text style={styles.modalToggleText}>Select Notification Time</Text>
           </TouchableOpacity>
-          <Text style={styles.dateTime}>{this.formatTime(this.state.notificationTime)}</Text>
+          <View style={styles.dateTimeContainer}>
+            <Text style={styles.dateTime}>{this.formatTime(this.state.notificationTime)}</Text>
+          </View>
           <Text style={styles.label}>Number of Companions:</Text>
           <TextInput
             keyboardType={"numeric"}

--- a/components/Trip/Trip.js
+++ b/components/Trip/Trip.js
@@ -315,7 +315,8 @@ export class Trip extends Component {
             <Text style={styles.modalToggleText}>Select Start Time</Text>
           </TouchableOpacity>
           <View style={styles.dateTimeContainer}>
-            <Text style={styles.dateTime}>{this.formatTime(this.state.startTime)}</Text>
+            {!this.state.selectedStartTime && <Text style={styles.dateTime}>Start Time</Text>}
+            {this.state.selectedStartTime && <Text style={styles.dateTime}>{this.formatTime(this.state.startTime)}</Text>}
           </View>
           <TouchableOpacity
             style={styles.modalToggleButton}
@@ -324,7 +325,8 @@ export class Trip extends Component {
             <Text style={styles.modalToggleText}>Select End Date</Text>
           </TouchableOpacity>
           <View style={styles.dateTimeContainer}>
-            <Text style={styles.dateTime}>{this.formatDate(this.state.endDate)}</Text>
+            {!this.state.selectedEndDate && <Text style={styles.dateTime}>End Date</Text>}
+            {this.state.selectedEndDate && <Text style={styles.dateTime}>{this.formatDate(this.state.endDate)}</Text>}
           </View>
           <TouchableOpacity
             style={styles.modalToggleButton}
@@ -333,7 +335,8 @@ export class Trip extends Component {
             <Text style={styles.modalToggleText}>Select End Time</Text>
           </TouchableOpacity>
           <View style={styles.dateTimeContainer}>
-            <Text style={styles.dateTime}>{this.formatTime(this.state.endTime)}</Text>
+            {!this.state.selectedEndTime && <Text style={styles.dateTime}>End Time</Text>}
+            {this.state.selectedEndTime && <Text style={styles.dateTime}>{this.formatTime(this.state.endTime)}</Text>}
           </View>
           <TouchableOpacity
             style={styles.modalToggleButton}
@@ -342,7 +345,8 @@ export class Trip extends Component {
             <Text style={styles.modalToggleText}>Select Notification Date</Text>
           </TouchableOpacity>
           <View style={styles.dateTimeContainer}>
-            <Text style={styles.dateTime}>{this.formatDate(this.state.notificationDate)}</Text>
+            {!this.state.selectedNotificationDate && <Text style={styles.dateTime}>Notification Date</Text>}
+            {this.state.selectedNotificationDate && <Text style={styles.dateTime}>{this.formatDate(this.state.notificationDate)}</Text>}
           </View>
           <TouchableOpacity
             style={styles.modalToggleButton}
@@ -351,7 +355,8 @@ export class Trip extends Component {
             <Text style={styles.modalToggleText}>Select Notification Time</Text>
           </TouchableOpacity>
           <View style={styles.dateTimeContainer}>
-            <Text style={styles.dateTime}>{this.formatTime(this.state.notificationTime)}</Text>
+            {!this.state.selectedNotificationTime && <Text style={styles.dateTime}>Notification Time</Text>}
+            {this.state.selectedNotificationTime && <Text style={styles.dateTime}>{this.formatTime(this.state.notificationTime)}</Text>}
           </View>
           <Text style={styles.label}>Number of Companions:</Text>
           <TextInput

--- a/components/Trip/Trip.js
+++ b/components/Trip/Trip.js
@@ -33,16 +33,22 @@ export class Trip extends Component {
       startingPoint: "",
       endingPoint: "",
       startDate: new Date(),
+      selectedStartDate: false,
       startDate_modal: false,
       startTime: new Date(),
+      selectedStartTime: false,
       startTime_modal: false,
       endDate: new Date(),
+      selectedEndDate: false,
       endDate_modal: false,
       endTime: new Date(),
+      selectedEndTime: false,
       endTime_modal: false,
       notificationDate: new Date(),
+      selectedNotification: false,
       notificationDate_modal: false,
       notificationTime: new Date(),
+      selectedNotificationTime: false,
       notificationTime_modal: false,
       travelingCompanions:""
     };
@@ -299,7 +305,8 @@ export class Trip extends Component {
             <Text style={styles.modalToggleText}>Select Start Date</Text>
           </TouchableOpacity>
           <View style={styles.dateTimeContainer}>
-            <Text style={styles.dateTime}>{this.formatDate(this.state.startDate)}</Text>
+            {!this.state.selectedStartDate && <Text style={styles.dateTime}>Start Date</Text>}
+            {this.state.selectedStartDate && <Text style={styles.dateTime}>{this.formatDate(this.state.startDate)}</Text>}
           </View>
           <TouchableOpacity
             style={styles.modalToggleButton}
@@ -406,7 +413,10 @@ export class Trip extends Component {
                 date={this.state.startDate}
                 onDateChange={(date) => this.setState({ startDate: date })}
                 />
-              <TouchableOpacity onPress={() => this.toggleModal("startDate_modal")}>
+              <TouchableOpacity onPress={() => {
+                this.setState({ selectedStartDate: true })
+                this.toggleModal("startDate_modal")
+                }}>
                 <Text style={styles.updateBtn}>Submit Start Date</Text>
               </TouchableOpacity>
             </View>

--- a/components/Trip/Trip.js
+++ b/components/Trip/Trip.js
@@ -364,7 +364,7 @@ export class Trip extends Component {
             {!this.state.selectedNotificationTime && <Text style={styles.dateTime}>Notification Time</Text>}
             {this.state.selectedNotificationTime && <Text style={styles.dateTime}>{this.formatTime(this.state.notificationTime)}</Text>}
           </View>
-          <Text style={styles.label}>Number of Companions:</Text>
+          <Text style={styles.companionsLabel}>Number of Companions:</Text>
           <TextInput
             keyboardType={"numeric"}
             placeholder="3"

--- a/components/Trip/styles.js
+++ b/components/Trip/styles.js
@@ -87,6 +87,14 @@ const styles = {
     textAlign: "left",
     paddingBottom: 2
   },
+  companionsLabel: {
+    color: "#001028",
+    fontFamily: "Georgia",
+    fontSize: 18,
+    textAlign: "left",
+    marginTop: 10,
+    paddingBottom: 2
+  },
   input: {
     backgroundColor: "#F0F0F0",
     borderColor: "#001028",

--- a/components/Trip/styles.js
+++ b/components/Trip/styles.js
@@ -132,7 +132,14 @@ const styles = {
     fontFamily: "Georgia",
     fontSize: 18,
     textAlign: "center",
-    paddingBottom: 4
+    paddingBottom: 4,
+  },
+  dateTimeContainer: {
+    borderBottomWidth: 2,
+    borderColor: "#001028",
+    marginBottom: 10,
+    marginTop: 5,
+    paddingBottom: 5
   }
 };
 


### PR DESCRIPTION
#### What does this PR do?
Display dates and times on Trip once a user specifies the date and time that they wanted to use for the trip. Also added styling to distinguish the displayed dates and times compared to the rest of the inputs.

#### Where should the reviewer start?
Trip.js

#### Any background context you want to provide?
So that the modal displays the current date and time for the user. I added a separate state, which keeps track on if the text or date/time should be displayed for each input.

#### What are the relevant tickets?
Hide dates and times until a user selects #175

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/45364533/69192288-84ca6f00-0ae1-11ea-9ec0-f77933076f95.png)